### PR TITLE
Add Laravel 13 and Boost 2.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-03-23
+
+### Added
+- Laravel 13 support
+- Laravel Boost 2.x support
+
 ## [0.1.1] - 2025-01-03
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0",
-        "laravel/boost": "^1.0"
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "laravel/boost": "^1.0|^2.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.0",


### PR DESCRIPTION
## Summary
- Adds `^13.0` to `illuminate/support` dependency constraint
- Adds `^2.0` to `laravel/boost` dependency constraint

## Notes
- No breaking changes in the package code — only constraint widening
- Laravel 13 upgrade guide: https://laravel.com/docs/13.x/upgrade